### PR TITLE
Accept header version proc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -496,8 +496,8 @@ api_base_url
 default_version
   Default API version to be used (1.0 by default)
 
-version_in_http_accept_header
-  name of the http accept header that contain the version
+version_request
+  Pass a proc in order to extract the version form the request.
 
 validate
   Parameters validation is turned off when set to false.

--- a/README.rst
+++ b/README.rst
@@ -496,6 +496,9 @@ api_base_url
 default_version
   Default API version to be used (1.0 by default)
 
+version_in_http_accept_header
+  name of the http accept header that contain the version
+
 validate
   Parameters validation is turned off when set to false.
 

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -3,7 +3,7 @@ module Apipie
 
     attr_accessor :app_name, :app_info, :copyright, :markup, :disqus_shortname,
       :api_base_url, :doc_base_url, :required_by_default, :layout,
-      :default_version, :version_in_http_accept_header,
+      :default_version, :version_request,
       :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -3,7 +3,8 @@ module Apipie
 
     attr_accessor :app_name, :app_info, :copyright, :markup, :disqus_shortname,
       :api_base_url, :doc_base_url, :required_by_default, :layout,
-      :default_version, :debug, :version_in_url, :namespaced_resources,
+      :default_version, :version_in_http_accept_header,
+      :debug, :version_in_url, :namespaced_resources,
       :validate, :validate_value, :validate_presence, :authenticate, :doc_path,
       :show_all_examples, :process_params, :update_checksum, :checksum_path,
       :link_extension, :record, :languages, :translate, :locale, :default_locale

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -41,10 +41,7 @@ module Apipie
         end
         @response_data = parse_data(response.body)
         @code = response.code
-        version_key = Apipie.configuration.version_in_http_accept_header
-        if version_key &&  request.env['HTTP_ACCEPT'] && request.env['HTTP_ACCEPT'].index("#{version_key}=")
-          @accept_version = request.env['HTTP_ACCEPT'].split("#{version_key}=").last
-        end
+        @version_request = Apipie.configuration.version_request.try :call, request
       end
 
       def parse_data(data)
@@ -73,7 +70,7 @@ module Apipie
            :verb => @verb,
            :path => @path,
            :params => @params,
-           :accept_version => @accept_version,
+           :version_request => @version_request,
            :query => @query,
            :request_data => @request_data,
            :response_data => @response_data,

--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -41,6 +41,10 @@ module Apipie
         end
         @response_data = parse_data(response.body)
         @code = response.code
+        version_key = Apipie.configuration.version_in_http_accept_header
+        if version_key &&  request.env['HTTP_ACCEPT'] && request.env['HTTP_ACCEPT'].index("#{version_key}=")
+          @accept_version = request.env['HTTP_ACCEPT'].split("#{version_key}=").last
+        end
       end
 
       def parse_data(data)
@@ -69,6 +73,7 @@ module Apipie
            :verb => @verb,
            :path => @path,
            :params => @params,
+           :accept_version => @accept_version,
            :query => @query,
            :request_data => @request_data,
            :response_data => @response_data,

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -113,7 +113,10 @@ module Apipie
           recorded_examples = calls.map do |call|
             method_descriptions = Apipie.get_method_descriptions(call[:controller], call[:action])
             call[:versions] = method_descriptions.map(&:version)
-
+            header_key_version = Apipie.configuration.version_in_http_accept_header
+            if header_key_version && call[:accept_version]
+              call[:versions] = [call[:accept_version]]
+            end
             if Apipie.configuration.show_all_examples
               show_in_doc = 1
             elsif call[:versions].any? { |v| ! showed_in_versions.include?(v) }

--- a/lib/apipie/extractor/writer.rb
+++ b/lib/apipie/extractor/writer.rb
@@ -113,9 +113,8 @@ module Apipie
           recorded_examples = calls.map do |call|
             method_descriptions = Apipie.get_method_descriptions(call[:controller], call[:action])
             call[:versions] = method_descriptions.map(&:version)
-            header_key_version = Apipie.configuration.version_in_http_accept_header
-            if header_key_version && call[:accept_version]
-              call[:versions] = [call[:accept_version]]
+            if call[:version_request]
+              call[:versions] = [call[:version_request]]
             end
             if Apipie.configuration.show_all_examples
               show_in_doc = 1


### PR DESCRIPTION
Allow to extract the version from the request information instead. The version can be inside the accept header or a cookie...
